### PR TITLE
Improve parser and add NPCs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,11 @@
 - Avoid adding external dependencies unless requested.
 
 ## Future TODOs
-- More NPC's
 - More NPC interactions
-- Improve parser (talk to hermit should enable you to talk to the hermit, not try to move to hermit)
 - Quests
 - Puzzles/Riddles
 - Specific item uses (Key for a locked door, herbs for healing, lump of iron for a quest etc.)
 - Dynamic weather
-- Room visit history
 - Save/Load system
 
 ## Tone

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ and `room.cpp` for clarity.
 - Fuzzy command recognition and synonyms
 - Simple inventory and item usage
 - Room descriptions, item examination, and more
+- Multiple NPCs with interactive dialogue
+- Improved parser for commands like `talk to hermit`
+- Rooms remember if you've visited them before
 
 ## Controls / Commands
 - `look` / `examine [item]` — View surroundings or inspect inventory items
@@ -32,14 +35,12 @@ Then run: ./vale
 - `room.cpp` – (currently empty) implementations for any Room methods
 
 ## TODO
-NPC's
-NPC interactions
-Quests
-Puzzles/Riddles
-Specific item uses (Key for a locked door, herbs for healing, lump of iron for a quest etc.)
-Dynamic weather
-Room visit history
-Save/Load system
+- NPC interactions
+- Quests
+- Puzzles/Riddles
+- Specific item uses (Key for a locked door, herbs for healing, lump of iron for a quest etc.)
+- Dynamic weather
+- Save/Load system
 
 ---
 


### PR DESCRIPTION
## Summary
- implement room visit history via `visitedRooms`
- add filler word removal for "to" and "with" and prioritise talking commands
- add traveller NPC with interactive dialogue
- update TODO lists in README and AGENTS files

## Testing
- `g++ ForgottenVale/main.cpp ForgottenVale/room.cpp -std=c++17 -o vale`
- `./vale <<EOF
look
exit
EOF`
- `./vale <<EOF
go south
talk traveller
1
3
exit
EOF`
- `./vale <<EOF
go south
talk to traveller
3
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6840691a924083279f96e518850d3dc4