### PR TITLE
Add quest NPC and crafting system

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ and `room.cpp` for clarity.
 - Improved parser for commands like `talk to hermit`
 - Rooms remember if you've visited them before
 - Dynamic weather events that shift as you explore
+- Simple quest system with item crafting and puzzles
 
 ## Controls / Commands
 - `look` / `examine [item]` — View surroundings or inspect inventory items
 - `go [direction]` — Move between rooms (north, south, east, west)
 - `take [item]` — Pick up an item from the current room
+- `combine [item1] [item2]` — Craft a new item from two others
 - `inventory` or `i` — Show carried items
 - `help` — List commands
 - `exit` — Quit game


### PR DESCRIPTION
## Summary
- implement quest tracking variables
- add ranger NPC offering a quest
- add crafting via `combine` command
- include torch quest to obtain the ornate key
- update README with new quest and combine command

## Testing
- `g++ -std=c++17 main.cpp room.cpp -o vale`
- `./vale <<EOF
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6842071b06b88327bf6ac93529b03299